### PR TITLE
feat: packages frontend/backend  in java and configures Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Use an official OpenJDK runtime as a parent image
-FROM openjdk:17-jdk-alpine
+FROM openjdk:17-jdk-slim
 
 # Set the working directory in the container
 WORKDIR /app
 
 # Copy the current directory contents into the container at /app
-COPY ./build /app
+COPY ./employee-manager-server/target /app
 
 # Expose port 8080 to the outside world
-EXPOSE 5173
+EXPOSE 8080
 
 # Run the application
-CMD ["java", "-jar", "libs/fullstack_demo-0.0.1-SNAPSHOT.jar"]
+CMD ["java", "-jar", "employee-mgr-server-0.0.1-SNAPSHOT.jar"]

--- a/employee-manager-server/.gitignore
+++ b/employee-manager-server/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Custom folders ###
+src/main/resources/react-static

--- a/employee-manager-server/pom.xml
+++ b/employee-manager-server/pom.xml
@@ -76,14 +76,6 @@
             <artifactId>hibernate-core</artifactId>
             <version>6.6.2.Final</version>
         </dependency>
-
-        <!-- JaCoCo Maven Plugin -->
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.8</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/employee-manager-server/pom.xml
+++ b/employee-manager-server/pom.xml
@@ -76,66 +76,9 @@
             <artifactId>hibernate-core</artifactId>
             <version>6.6.2.Final</version>
         </dependency>
-
-        <!-- JaCoCo Maven Plugin -->
-        <dependency>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.8</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>
-            <!-- Maven Surefire Plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
-            </plugin>
-
-            <!-- JaCoCo Maven Plugin -->
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
-                <executions>
-                    <execution>
-                        <id>default-prepare-agent</id>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule>
-                                    <element>BUNDLE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>COMPLEXITY</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- Spring Boot Maven Plugin -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/employee-manager-server/pom.xml
+++ b/employee-manager-server/pom.xml
@@ -76,6 +76,14 @@
             <artifactId>hibernate-core</artifactId>
             <version>6.6.2.Final</version>
         </dependency>
+
+        <!-- JaCoCo Maven Plugin -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.8</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/employee-manager-server/pom.xml
+++ b/employee-manager-server/pom.xml
@@ -13,6 +13,7 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>employee-mgr-server</name>
     <description>Employee Manager server for Capstone Project</description>
+    <packaging>jar</packaging>
 
     <properties>
         <java.version>17</java.version>
@@ -75,12 +76,128 @@
             <artifactId>hibernate-core</artifactId>
             <version>6.6.2.Final</version>
         </dependency>
+
+        <!-- JaCoCo Maven Plugin -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.8</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
+            <!-- Maven Surefire Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
+
+            <!-- JaCoCo Maven Plugin -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.20</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Spring Boot Maven Plugin -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>npm-install</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>install</argument>
+                            </arguments>
+                            <workingDirectory>${project.basedir}/../employee-manager-client-frontend</workingDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>npm-build</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>build</argument>
+                            </arguments>
+                            <workingDirectory>${project.basedir}/../employee-manager-client-frontend</workingDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-dist</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>cp</executable>
+                            <arguments>
+                                <argument>-r</argument>
+                                <argument>${project.basedir}/../employee-manager-client-frontend/dist/</argument>
+                                <argument>${project.basedir}/src/main/resources/react-static/</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/employee-manager-server/pom.xml
+++ b/employee-manager-server/pom.xml
@@ -78,6 +78,11 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>  
+        </resources>
         <plugins>
             <!-- Spring Boot Maven Plugin -->
             <plugin>

--- a/employee-manager-server/src/main/java/com/employee_mgr_server/ReactController.java
+++ b/employee-manager-server/src/main/java/com/employee_mgr_server/ReactController.java
@@ -1,0 +1,14 @@
+package com.employee_mgr_server;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ReactController {
+
+    @GetMapping(value = {"/"})
+    public String redirectToReact() {
+        // Return the React app's index.html
+        return "forward:/index.html";
+    }
+}

--- a/employee-manager-server/src/main/java/com/employee_mgr_server/WebConfiguration.java
+++ b/employee-manager-server/src/main/java/com/employee_mgr_server/WebConfiguration.java
@@ -1,0 +1,16 @@
+package com.employee_mgr_server;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfiguration implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/react-static/")
+                .addResourceLocations("classpath:/static/");
+    }
+}

--- a/employee-manager-server/src/main/java/com/employee_mgr_server/domain/employee/models/Employee.java
+++ b/employee-manager-server/src/main/java/com/employee_mgr_server/domain/employee/models/Employee.java
@@ -9,9 +9,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 @Data
 public class Employee {

--- a/employee-manager-server/src/main/java/com/employee_mgr_server/domain/employee/models/Employee.java
+++ b/employee-manager-server/src/main/java/com/employee_mgr_server/domain/employee/models/Employee.java
@@ -9,10 +9,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 
 @Entity
-@NoArgsConstructor
-@RequiredArgsConstructor
+@Builder
 @Data
 public class Employee {
 


### PR DESCRIPTION
This change makes it possible to deploy the frontend/backend via a single Docker image by allowing the frontend to be served via the Java web server. Before attempting to deploy with Fly.io, you'll need to build the server using the following command:

```bash
mvn clean package spring-boot:repackage -DskipTests
``` 

To test the Docker container, run the following commands:

```bash
docker build --tag employee-mgr-server . --platform=linux/amd64  
docker run -p 8080:8080 employee-mgr-server
```

Lastly, I removed the spring-boot-security-starter dependency since it didn't seem like it wasn't being used and wasn't configured anyway.

- **feat: packages frontend into java web server and configured Dockerfile**
- **chore: adds missing files**
